### PR TITLE
Add automatic cleanup for stale code submissions

### DIFF
--- a/config/celery.py
+++ b/config/celery.py
@@ -20,3 +20,11 @@ app.conf.task_routes = {
 
 # Default queue for other tasks
 app.conf.task_default_queue = 'default'
+
+# Celery Beat schedule — periodic tasks
+app.conf.beat_schedule = {
+    'cleanup-stale-submissions': {
+        'task': 'quizzes.tasks.cleanup_stale_submissions',
+        'schedule': 1800,  # every 30 minutes
+    },
+}

--- a/config/settings.py
+++ b/config/settings.py
@@ -162,7 +162,7 @@ CELERY_TASK_SERIALIZER = 'json'
 CELERY_RESULT_SERIALIZER = 'json'
 CELERY_TIMEZONE = TIME_ZONE
 CELERY_TASK_TRACK_STARTED = True
-CELERY_TASK_TIME_LIMIT = 60  # 60 seconds max per task
+CELERY_TASK_TIME_LIMIT = 300  # 5 minutes max per task
 
 # Django Channels Configuration
 CHANNEL_LAYERS = {


### PR DESCRIPTION
## Summary
- Added Celery Beat periodic task that runs every 30 minutes to clean up stale code submissions
- Automatically marks submissions stuck in pending/running state for 10+ minutes as error with timeout message
- Increased CELERY_TASK_TIME_LIMIT from 60s to 300s (5 minutes) to allow longer code execution
- Sends WebSocket notification so student UI updates in real-time instead of spinning forever

## Test plan
- [x] Verify Celery Beat runs cleanup task on schedule
- [x] Create a test submission, manually set old timestamp, confirm it gets cleaned up
- [x] Trigger manually with `cleanup_stale_submissions.delay()` and verify status changes to error
- [x] Check WebSocket notification updates the browser UI
- [x] Deploy with `celery -A config beat -l info` service on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)